### PR TITLE
Add link to original chintz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # chintz-ruby
-Ruby implementation of BBC News Chintz
+Ruby implementation of [BBC News Chintz](https://github.com/BBC-News/chintz)


### PR DESCRIPTION
Reduces the steps required for a user to go and see the original library and learn about what it is
